### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/bearholmes/mongmung_csslint_web_client/security/code-scanning/10](https://github.com/bearholmes/mongmung_csslint_web_client/security/code-scanning/10)

To fix this, explicitly declare a minimal `permissions` block so the `GITHUB_TOKEN` used in this CI job has only the rights it needs. Since the job only checks out and reads the repository, it can safely use `contents: read`. This should be added at the job level under `test:` (or at the root level for all jobs). Adding it at the job level minimizes assumptions about other workflows.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Under `jobs: test:`, add a `permissions:` section before `runs-on: ubuntu-latest`.
- Set `contents: read` as recommended by CodeQL.

No additional imports, methods, or external dependencies are required, as this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
